### PR TITLE
fix: NFC write flow after tag discovery (closes #5)

### DIFF
--- a/android/src/main/java/app/capgo/nfc/CapacitorNfcPlugin.java
+++ b/android/src/main/java/app/capgo/nfc/CapacitorNfcPlugin.java
@@ -301,7 +301,9 @@ public class CapacitorNfcPlugin extends Plugin {
                         ndef.writeNdefMessage(message);
                         call.resolve();
                     }
-                    ndef.close();
+                    if (ndef.isConnected()) {
+                        ndef.close();
+                    }
                 } else if (allowFormat) {
                     NdefFormatable formatable = NdefFormatable.get(tag);
                     if (formatable != null) {

--- a/example-app/src/main.js
+++ b/example-app/src/main.js
@@ -14,6 +14,7 @@ const textInput = document.getElementById('text-input');
 const langInput = document.getElementById('lang-input');
 
 let sessionActive = false;
+let sessionInvalidateAfterFirstRead = true;
 const logBuffer = [];
 const LOG_LIMIT = 40;
 
@@ -97,6 +98,7 @@ async function refreshStatus() {
 
 startButton.addEventListener('click', async () => {
   try {
+    sessionInvalidateAfterFirstRead = false;
     await CapacitorNfc.startScanning({
       invalidateAfterFirstRead: false,
       alertMessage: 'Hold an NFC tag near the top of your device.',
@@ -151,14 +153,17 @@ CapacitorNfc.addListener('nfcEvent', async (event) => {
   updateSessionIndicator(true);
   appendLog('📡 Tag discovered', event);
 
-  // Stop scanning after reading the tag
-  try {
-    await CapacitorNfc.stopScanning();
-    sessionActive = false;
-    updateSessionIndicator(false);
-    appendLog('🛑 Scanning stopped after reading tag');
-  } catch (error) {
-    appendLog('⚠️ Failed to stop scanning after reading tag', error);
+  if (sessionInvalidateAfterFirstRead) {
+    try {
+      await CapacitorNfc.stopScanning();
+      sessionActive = false;
+      updateSessionIndicator(false);
+      appendLog('🛑 Scanning stopped after reading tag');
+    } catch (error) {
+      appendLog('⚠️ Failed to stop scanning after reading tag', error);
+    }
+  } else {
+    appendLog('ℹ️ Tag ready for writing — keep it on the reader and tap Write.');
   }
 });
 

--- a/ios/Sources/NfcPlugin/NfcPlugin.swift
+++ b/ios/Sources/NfcPlugin/NfcPlugin.swift
@@ -527,6 +527,12 @@ extension NfcPlugin: NFCNDEFReaderSessionDelegate {
 
                 tag.readNDEF { message, readError in
                     if let readError {
+                        if !self.invalidateAfterFirstRead && status == .readWrite {
+                            self.currentTag = tag
+                            let event = self.buildEvent(tag: tag, status: status, capacity: capacity, message: nil)
+                            self.notify(event: event)
+                            return
+                        }
                         session.invalidate(errorMessage: "Failed to read NDEF message: \(readError.localizedDescription)")
                         return
                     }
@@ -706,7 +712,7 @@ extension NfcPlugin: NFCTagReaderSessionDelegate {
 
             if error == nil && status != .notSupported {
                 // Tag supports NDEF, try to read it
-                tag.readNDEF { [weak self] message, _ in
+                tag.readNDEF { [weak self] message, readError in
                     guard let self else {
                         return
                     }
@@ -717,8 +723,10 @@ extension NfcPlugin: NFCTagReaderSessionDelegate {
                     if message == nil {
                         // Blank tag or NDEF read failed - emit tag with UID and status info
                         self.emitTagEvent(tag: tag, status: status, capacity: capacity, message: nil, session: session)
+                    } else if readError != nil && self.invalidateAfterFirstRead {
+                        session.invalidate(errorMessage: "Failed to read NDEF message: \(readError!.localizedDescription)")
                     } else {
-                        // Successfully read NDEF
+                        // Successfully read NDEF (or keep session open for writes after a read error)
                         self.currentTag = tag
                         let event = self.buildEvent(tag: tag, status: status, capacity: capacity, message: message)
                         self.notify(event: event)


### PR DESCRIPTION
## Summary
- Keep iOS NDEF reader sessions alive for writable tags when `invalidateAfterFirstRead` is `false`, even if `readNDEF` fails on empty tags, so `write()` still has a connected tag.
- Align tag-reader session NDEF read error handling with the write workflow.
- Fix the example app so it no longer calls `stopScanning()` after every discovery while demoing writes (`invalidateAfterFirstRead: false`).
- Close `Ndef` connections safely on Android after write attempts.

## Test plan
- [x] `bun run verify` (iOS SwiftPM, Android Gradle tests/lint, web build)
- [ ] On device: `startScanning({ invalidateAfterFirstRead: false })` → tap blank NTAG → `write()` text record → re-read tag
- [ ] On device: example app write card flow without scanning stopping after first tap

Closes #5

Made with [Cursor](https://cursor.com)