### PR TITLE
fix(android): handle stale NFC tags during writes

### DIFF
--- a/android/src/main/java/app/capgo/nfc/CapacitorNfcPlugin.java
+++ b/android/src/main/java/app/capgo/nfc/CapacitorNfcPlugin.java
@@ -169,6 +169,8 @@ public class CapacitorNfcPlugin extends Plugin {
                 } else {
                     call.reject("Failed to make the tag read only.");
                 }
+            } catch (SecurityException | IllegalStateException e) {
+                call.reject("Tag connection lost.", e);
             } catch (IOException e) {
                 call.reject("Failed to make the tag read only.", e);
             }
@@ -317,6 +319,8 @@ public class CapacitorNfcPlugin extends Plugin {
                 } else {
                     call.reject("Tag does not support NDEF.");
                 }
+            } catch (SecurityException | IllegalStateException e) {
+                call.reject("Tag connection lost.", e);
             } catch (IOException | FormatException e) {
                 call.reject("Failed to write NDEF message.", e);
             }


### PR DESCRIPTION
## What

- Catch stale Android NFC tag `SecurityException` and `IllegalStateException` failures in write, format, and make-read-only operations.
- Reject the Capacitor call with `Tag connection lost.` instead of letting the executor exception terminate the app process.

## Why

Android invalidates a `Tag` handle after the tag leaves the NFC field or is re-discovered. A later `connect()` can then throw `SecurityException: Permission Denial: Tag ... is out of date`. The write and make-read-only paths only caught checked NFC I/O exceptions, so this runtime exception escaped the executor and crashed the app.

## How

- Added the same stale-tag runtime exception handling to `performWrite()` and `makeReadOnly()`.
- Kept existing handling for `IOException` and `FormatException` unchanged.

## Testing

- `bun run fmt`
- `bun run verify:android` — passed, including Android unit tests and lint
- `bun run verify:web` — passed
- `git diff --check` — passed

## Not Tested

- Physical stale-tag reproduction on the reported Samsung SM-S146VL.
- Full `bun run verify` could not complete locally because Xcode does not have the iOS 26.4 platform installed.
- `bun run lint` reaches an existing SwiftLint `type_body_length` error in untouched `ios/Sources/NfcPlugin/NfcPlugin.swift`.

This PR was prepared with AI assistance.

Closes #44
