### PR TITLE
feat: emit iOS NFC session end reasons

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,23 @@ await listener.remove();
 await CapacitorNfc.stopScanning();
 ```
 
+### Handling iOS session endings
+
+Listen for `nfcSessionEnd` to distinguish a user cancellation from a session timeout or another Core NFC error. The event is available for both `ndef` and `tag` iOS sessions. A normal first-read completion does not emit this event.
+
+```ts
+const sessionEndListener = await CapacitorNfc.addListener('nfcSessionEnd', ({ reason }) => {
+  if (reason === 'userCancelled') {
+    return;
+  }
+
+  console.warn(reason === 'sessionTimeout' ? 'No tag detected. Try again.' : 'The NFC session failed.');
+});
+
+// Later, when the listener is no longer needed
+await sessionEndListener.remove();
+```
+
 ## API
 
 <docgen-index>
@@ -165,6 +182,7 @@ await CapacitorNfc.stopScanning();
 * [`addListener('nfcEvent', ...)`](#addlistenernfcevent-)
 * [`addListener('tagDiscovered' | 'ndefDiscovered' | 'ndefMimeDiscovered' | 'ndefFormatableDiscovered', ...)`](#addlistenertagdiscovered--ndefdiscovered--ndefmimediscovered--ndefformatablediscovered-)
 * [`addListener('nfcStateChange', ...)`](#addlistenernfcstatechange-)
+* [`addListener('nfcSessionEnd', ...)`](#addlistenernfcsessionend-)
 * [Interfaces](#interfaces)
 * [Type Aliases](#type-aliases)
 
@@ -372,6 +390,22 @@ addListener(eventName: 'nfcStateChange', listenerFunc: (event: NfcStateChangeEve
 --------------------
 
 
+### addListener('nfcSessionEnd', ...)
+
+```typescript
+addListener(eventName: 'nfcSessionEnd', listenerFunc: (event: NfcSessionEndEvent) => void) => Promise<PluginListenerHandle>
+```
+
+| Param              | Type                                                                                  |
+| ------------------ | ------------------------------------------------------------------------------------- |
+| **`eventName`**    | <code>'nfcSessionEnd'</code>                                                          |
+| **`listenerFunc`** | <code>(event: <a href="#nfcsessionendevent">NfcSessionEndEvent</a>) =&gt; void</code> |
+
+**Returns:** <code>Promise&lt;<a href="#pluginlistenerhandle">PluginListenerHandle</a>&gt;</code>
+
+--------------------
+
+
 ### Interfaces
 
 
@@ -467,6 +501,17 @@ Event emitted whenever the NFC adapter availability changes.
 | ------------- | ----------------------------------------------- |
 | **`status`**  | <code><a href="#nfcstatus">NfcStatus</a></code> |
 | **`enabled`** | <code>boolean</code>                            |
+
+
+#### NfcSessionEndEvent
+
+Event emitted when an iOS NFC reader session ends.
+
+This event is not emitted when a session closes normally after its first successful read.
+
+| Prop         | Type                                                              |
+| ------------ | ----------------------------------------------------------------- |
+| **`reason`** | <code>'userCancelled' \| 'sessionTimeout' \| 'invalidated'</code> |
 
 
 ### Type Aliases

--- a/ios/Sources/NfcPlugin/NfcPlugin.swift
+++ b/ios/Sources/NfcPlugin/NfcPlugin.swift
@@ -2,6 +2,19 @@ import Capacitor
 import CoreNFC
 import UIKit
 
+func nfcSessionEndReason(for error: Error) -> String? {
+    switch (error as NSError).code {
+    case NFCReaderError.readerSessionInvalidationErrorFirstNDEFTagRead.rawValue:
+        return nil
+    case NFCReaderError.readerSessionInvalidationErrorUserCanceled.rawValue:
+        return "userCancelled"
+    case NFCReaderError.readerSessionInvalidationErrorSessionTimeout.rawValue:
+        return "sessionTimeout"
+    default:
+        return "invalidated"
+    }
+}
+
 @objc(NfcPlugin)
 public class NfcPlugin: CAPPlugin, CAPBridgedPlugin {
     private let pluginVersion: String = "8.1.7"
@@ -44,6 +57,16 @@ public class NfcPlugin: CAPPlugin, CAPBridgedPlugin {
 
     private func isNfcAvailable() -> Bool {
         NFCTagReaderSession.readingAvailable || NFCNDEFReaderSession.readingAvailable
+    }
+
+    private func notifySessionEnd(for error: Error) {
+        guard let reason = nfcSessionEndReason(for: error) else {
+            return
+        }
+
+        DispatchQueue.main.async {
+            self.notifyListeners("nfcSessionEnd", data: ["reason": reason], retainUntilConsumed: true)
+        }
     }
 
     private func pollingOptions(_ requestedPollingOptions: JSArray) -> NFCTagReaderSession.PollingOption {
@@ -492,6 +515,7 @@ public class NfcPlugin: CAPPlugin, CAPBridgedPlugin {
 extension NfcPlugin: NFCNDEFReaderSessionDelegate {
     public func readerSession(_ session: NFCNDEFReaderSession, didInvalidateWithError error: Error) {
         currentTag = nil
+        notifySessionEnd(for: error)
         if (error as NSError).code != NFCReaderError.readerSessionInvalidationErrorFirstNDEFTagRead.rawValue {
             DispatchQueue.main.async {
                 let payload: [String: Any] = [
@@ -632,6 +656,7 @@ extension NfcPlugin: NFCTagReaderSessionDelegate {
                 return
             }
 
+            notifySessionEnd(for: error)
             pendingStartCall = nil
             pendingStartSession = nil
             pendingAlertMessage = nil
@@ -651,6 +676,7 @@ extension NfcPlugin: NFCTagReaderSessionDelegate {
         }
 
         currentTag = nil
+        notifySessionEnd(for: error)
 
         // Don't emit state change for normal session completion (user canceled)
         // Also check for successful read completion

--- a/ios/Tests/NfcPluginTests/NfcPluginTests.swift
+++ b/ios/Tests/NfcPluginTests/NfcPluginTests.swift
@@ -1,3 +1,4 @@
+import CoreNFC
 import XCTest
 
 @testable import NfcPlugin
@@ -6,5 +7,19 @@ final class NfcPluginTests: XCTestCase {
     func testPluginCanBeInitialised() {
         let plugin = NfcPlugin()
         XCTAssertNotNil(plugin)
+    }
+
+    func testSessionEndReasons() {
+        XCTAssertEqual(reason(for: NFCReaderError.readerSessionInvalidationErrorUserCanceled.rawValue), "userCancelled")
+        XCTAssertEqual(reason(for: NFCReaderError.readerSessionInvalidationErrorSessionTimeout.rawValue), "sessionTimeout")
+        XCTAssertEqual(reason(for: -1), "invalidated")
+    }
+
+    func testFirstReadCompletionDoesNotHaveSessionEndReason() {
+        XCTAssertNil(reason(for: NFCReaderError.readerSessionInvalidationErrorFirstNDEFTagRead.rawValue))
+    }
+
+    private func reason(for errorCode: Int) -> String? {
+        nfcSessionEndReason(for: NSError(domain: "NfcPluginTests", code: errorCode))
     }
 }

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -169,6 +169,15 @@ export interface NfcStateChangeEvent {
 }
 
 /**
+ * Event emitted when an iOS NFC reader session ends.
+ *
+ * This event is not emitted when a session closes normally after its first successful read.
+ */
+export interface NfcSessionEndEvent {
+  reason: 'userCancelled' | 'sessionTimeout' | 'invalidated';
+}
+
+/**
  * Public API surface for the Capacitor NFC plugin.
  *
  * The interface intentionally mirrors the behaviour of the reference PhoneGap
@@ -235,6 +244,10 @@ export interface CapacitorNfcPlugin {
   addListener(
     eventName: 'nfcStateChange',
     listenerFunc: (event: NfcStateChangeEvent) => void,
+  ): Promise<PluginListenerHandle>;
+  addListener(
+    eventName: 'nfcSessionEnd',
+    listenerFunc: (event: NfcSessionEndEvent) => void,
   ): Promise<PluginListenerHandle>;
 }
 

--- a/src/web.ts
+++ b/src/web.ts
@@ -2,6 +2,7 @@ import { WebPlugin } from '@capacitor/core';
 
 import type {
   CapacitorNfcPlugin,
+  NfcSessionEndEvent,
   NfcStateChangeEvent,
   NfcEvent,
   ShareTagOptions,
@@ -67,6 +68,10 @@ export class CapacitorNfcWeb extends WebPlugin implements CapacitorNfcPlugin {
   addListener(
     eventName: 'nfcStateChange',
     listenerFunc: (event: NfcStateChangeEvent) => void,
+  ): Promise<PluginListenerHandle>;
+  addListener(
+    eventName: 'nfcSessionEnd',
+    listenerFunc: (event: NfcSessionEndEvent) => void,
   ): Promise<PluginListenerHandle>;
   async addListener(eventName: string, _listenerFunc: (..._args: any[]) => any): Promise<PluginListenerHandle> {
     this.unsupported(`addListener(${eventName})`);


### PR DESCRIPTION
## What

- add a typed `nfcSessionEnd` listener with `userCancelled`, `sessionTimeout`, and `invalidated` reasons
- emit the event from both iOS Core NFC session delegates
- suppress the event for normal `FirstNDEFTagRead` completion
- document the listener and add regression coverage for the error mapping

## Why

Apps could only infer why the iOS Core NFC sheet closed by matching rejected-call error strings. That does not cover sessions ending after `startScanning()` has resolved and cannot reliably distinguish cancellation, timeout, and system failures.

Closes #46

## How

A shared Core NFC error mapper now drives both delegate implementations. It maps user cancellation and timeout explicitly, treats other errors as invalidation, and returns no event for the successful first-NDEF-read invalidation code. The public TypeScript API exposes the exact reason union.

## Impact

Apps can quietly reset after cancellation, show retry guidance after timeout, and reserve generic error handling for actual invalidations without parsing native error text. Android behavior is unchanged.

## Testing

- `bun run build`
- `bun run verify:web`
- `bun run verify:android`
- `bun run check:wiring`
- `git diff --check`
- added Swift regression tests for all three reasons and first-read suppression

## Not Tested

- physical iOS NFC interaction was not tested locally
- local `bun run verify:ios` could not select an iOS destination because the installed Xcode lacks the iOS 26.4 platform; CI will perform the iOS build

This PR was prepared with AI assistance and verified against the repository checks listed above.
